### PR TITLE
Fix for broken Dark theme - trailing comma bug

### DIFF
--- a/themes/WinterIsComing-dark-color-theme.json
+++ b/themes/WinterIsComing-dark-color-theme.json
@@ -226,7 +226,7 @@
     {
       "name": "Meta - Decorator",
       "scope": [
-        "punctuation.decorator",
+        "punctuation.decorator"
       ],
       "settings": {
         "fontStyle": "italic",


### PR DESCRIPTION
The changes from 03-03-2018 for v.0.50 broke the dark theme due to a trailing comma. this fixes it. 

## What to Check
Verify that the following are valid
- Dark theme works. 