### PR TITLE
Add AI-ready repo configuration

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,29 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "local",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Winter is Coming theme Changelog
 
+## Unreleased
+
+- Enabled semantic highlighting across all 6 theme variants. Fixes [#45](https://github.com/johnpapa/vscode-winteriscoming/issues/45)
+- Added GitHub Copilot repo configuration with `.mcp.json` and `.github/workflows/copilot-setup-steps.yml`
+- Updated GitHub Actions dependencies for the packaging workflow
+
 <a name="1.4.3"></a>
 
 ## 1.4.4 (2021-03-08)


### PR DESCRIPTION
## Summary
- add repo-level `.mcp.json` configuration for GitHub MCP access
- add `.github/workflows/copilot-setup-steps.yml` for Copilot cloud-agent setup
- add an `Unreleased` changelog entry for the AI-ready and workflow updates

## Validation
- `npx @vscode/vsce package --no-dependencies`

## Notes
- PR #82 is still open separately and is blocked only by missing GitHub `workflow` scope on the current credentials.