### PR TITLE
fix: reduce dark theme line highlight opacity to distinguish from selection (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Winter is Coming theme Changelog
 
+<a name="1.4.5"></a>
+
+## 1.4.5 (2026-07-20)
+
+- Reduced `editor.lineHighlightBackground` opacity in all four dark theme variants from `#0c499477` to `#0c499444` so the current line is clearly distinct from selected text. Fixes [#70](https://github.com/johnpapa/vscode-winteriscoming/issues/70)
+
 <a name="1.4.3"></a>
 
 ## 1.4.4 (2021-03-08)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "color": "#373436",
     "theme": "dark"
   },
-  "version": "1.4.4",
+  "version": "1.4.5",
   "publisher": "johnpapa",
   "keywords": [
     "Theme",

--- a/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
@@ -561,7 +561,7 @@
     "editor.foreground": "#a7dbf7",
     "editor.inactiveSelectionBackground": "#7e57c25a",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",

--- a/themes/WinterIsComing-dark-blue-color-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-theme.json
@@ -542,7 +542,7 @@
     "editor.foreground": "#a7dbf7",
     "editor.inactiveSelectionBackground": "#7e57c25a",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",

--- a/themes/WinterIsComing-dark-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-color-no-italics-theme.json
@@ -527,7 +527,7 @@
     "editor.background": "#282822",
     "editor.foreground": "#a7dbf7",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",

--- a/themes/WinterIsComing-dark-color-theme.json
+++ b/themes/WinterIsComing-dark-color-theme.json
@@ -541,7 +541,7 @@
     "editor.background": "#282822",
     "editor.foreground": "#a7dbf7",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",


### PR DESCRIPTION
## Summary

Fixes #70. In all four dark theme variants, `editor.lineHighlightBackground` (`#0c499477`) was visually indistinguishable from `editor.selectionBackground` (`#103362`) — both rendered as a similar shade of dark blue. The reporter also noted the line highlight was "too bright."

## Change

Reduce `editor.lineHighlightBackground` alpha from `77` (~47% opacity) to `44` (~27% opacity) across all dark variants:

```diff
- "editor.lineHighlightBackground": "#0c499477",
+ "editor.lineHighlightBackground": "#0c499444",
```

This makes the current-line indicator clearly more subtle than selected text while still being visible.

## Affected files

- `themes/WinterIsComing-dark-blue-color-theme.json`
- `themes/WinterIsComing-dark-blue-color-no-italics-theme.json`
- `themes/WinterIsComing-dark-color-theme.json`
- `themes/WinterIsComing-dark-color-no-italics-theme.json`

Light themes are unaffected (they already use a distinct `#eff2ef` for line highlight vs `#cee1f0` for selection).

## Validation

`npx @vscode/vsce package --no-dependencies` completes successfully producing `winteriscoming-1.4.5.vsix`.