### PR TITLE
fix: improve debugExceptionWidget contrast in light themes (#47)

### DIFF
--- a/themes/WinterIsComing-light-color-no-italics-theme.json
+++ b/themes/WinterIsComing-light-color-no-italics-theme.json
@@ -517,7 +517,7 @@
     "contrastActiveBorder": "#ccc",
     "contrastBorder": "#ccc",
     "foreground": "#1857a4",
-    "debugExceptionWidget.background": "#357ab3",
+    "debugExceptionWidget.background": "#dce9f5",
     "debugToolBar.background": "#fff",
     "diffEditor.insertedTextBackground": "#99b76d23",
     "diffEditor.insertedTextBorder": "#addb6733",

--- a/themes/WinterIsComing-light-color-theme.json
+++ b/themes/WinterIsComing-light-color-theme.json
@@ -531,7 +531,7 @@
     "contrastActiveBorder": "#ccc",
     "contrastBorder": "#ccc",
     "foreground": "#1857a4",
-    "debugExceptionWidget.background": "#357ab3",
+    "debugExceptionWidget.background": "#dce9f5",
     "debugToolBar.background": "#fff",
     "diffEditor.insertedTextBackground": "#99b76d23",
     "diffEditor.insertedTextBorder": "#addb6733",


### PR DESCRIPTION
## Summary

Fixes #47 — in VS Code light themes, the debug exception overlay widget had near-identical background and text colors, making exception messages unreadable.

**Root cause:** `debugExceptionWidget.background` was set to `#357ab3` (medium-dark blue) while the editor foreground is `#236ebf` (also dark blue) — essentially invisible text on a similar-colored background.

**Fix:** Changed `debugExceptionWidget.background` to `#dce9f5` (very light blue) in both light theme variants, providing strong contrast for dark-blue text while staying harmonious with the theme palette.

## Files changed

- `themes/WinterIsComing-light-color-theme.json`
- `themes/WinterIsComing-light-color-no-italics-theme.json`

## Validation

Packaged successfully with `npx @vscode/vsce package --no-dependencies`.