### PR TITLE
Add markup.deleted, markup.inserted, markup.underline token rules to all themes

### DIFF
--- a/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
@@ -160,7 +160,7 @@
       "name": "JavaScript Other Variable",
       "scope": "variable.other.object.js",
       "settings": {
-        "foreground": "#d6deeb",
+        "foreground": "#d6deeb"
       }
     },
     {
@@ -527,6 +527,30 @@
       "scope": "meta.link",
       "settings": {
         "foreground": "#78BD65"
+      }
+    },
+    {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#f97583"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#addb67"
+      }
+    },
+    {
+      "name": "Markup Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#6dbdfa"
       }
     },
     {

--- a/themes/WinterIsComing-dark-blue-color-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-theme.json
@@ -511,6 +511,30 @@
       }
     },
     {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#f97583"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#addb67"
+      }
+    },
+    {
+      "name": "Markup Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#6dbdfa"
+      }
+    },
+    {
       "name": "Dockerfile",
       "scope": "source.dockerfile",
       "settings": {

--- a/themes/WinterIsComing-dark-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-color-no-italics-theme.json
@@ -497,6 +497,30 @@
       }
     },
     {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#f97583"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#addb67"
+      }
+    },
+    {
+      "name": "Markup Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#6dbdfa"
+      }
+    },
+    {
       "name": "Dockerfile",
       "scope": "source.dockerfile",
       "settings": {

--- a/themes/WinterIsComing-dark-color-theme.json
+++ b/themes/WinterIsComing-dark-color-theme.json
@@ -511,6 +511,30 @@
       }
     },
     {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#f97583"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#addb67"
+      }
+    },
+    {
+      "name": "Markup Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#6dbdfa"
+      }
+    },
+    {
       "name": "Dockerfile",
       "scope": "source.dockerfile",
       "settings": {

--- a/themes/WinterIsComing-light-color-no-italics-theme.json
+++ b/themes/WinterIsComing-light-color-no-italics-theme.json
@@ -497,6 +497,30 @@
       }
     },
     {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "name": "Markup Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#207bb8"
+      }
+    },
+    {
       "name": "Dockerfile",
       "scope": "source.dockerfile",
       "settings": {

--- a/themes/WinterIsComing-light-color-theme.json
+++ b/themes/WinterIsComing-light-color-theme.json
@@ -511,6 +511,30 @@
       }
     },
     {
+      "name": "Markup Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#b31d28"
+      }
+    },
+    {
+      "name": "Markup Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "fontStyle": "",
+        "foreground": "#22863a"
+      }
+    },
+    {
+      "name": "Markup Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline",
+        "foreground": "#207bb8"
+      }
+    },
+    {
       "name": "Dockerfile",
       "scope": "source.dockerfile",
       "settings": {


### PR DESCRIPTION
Closes #57

## Problem
Winter is Coming themes did not define generic markup TextMate scopes, so extensions using `markup.deleted`, `markup.inserted`, or `markup.underline` tokens received no syntax highlighting.

## Changes
Added three `tokenColors` entries to all six theme files:

| Scope | Dark themes | Light themes | Style |
|---|---|---|---|
| `markup.deleted` | `#f97583` | `#b31d28` | `strikethrough` |
| `markup.inserted` | `#addb67` | `#22863a` | — |
| `markup.underline` | `#6dbdfa` | `#207bb8` | `underline` |

The no-italics variants receive the same rules (strikethrough and underline are preserved; only italics are stripped).

## Validation
`npx @vscode/vsce package --no-dependencies` completes successfully.