### PR TITLE
Fix terminal link hover highlight colors

### DIFF
--- a/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
@@ -662,6 +662,7 @@
     "tab.inactiveForeground": "#5f7e97",
     "tab.activeBorderTop": "#219fd5",
     "terminal.ansiBlack": "#011627",
+    "terminal.hoverHighlightBackground": "#219fd544",
     "textLink.foreground": "#219fd5",
     "textLink.activeForeground": "#98c8ed",
     "titleBar.activeBackground": "#112233",

--- a/themes/WinterIsComing-dark-blue-color-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-theme.json
@@ -643,6 +643,7 @@
     "tab.inactiveForeground": "#5f7e97",
     "tab.activeBorderTop": "#219fd5",
     "terminal.ansiBlack": "#011627",
+    "terminal.hoverHighlightBackground": "#219fd544",
     "textLink.foreground": "#219fd5",
     "textLink.activeForeground": "#98c8ed",
     "titleBar.activeBackground": "#112233",

--- a/themes/WinterIsComing-dark-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-color-no-italics-theme.json
@@ -629,6 +629,7 @@
     "tab.inactiveForeground": "#5f7e97",
     "tab.activeBorderTop": "#219fd5",
     "terminal.ansiBlack": "#282822",
+    "terminal.hoverHighlightBackground": "#219fd544",
     "textLink.foreground": "#219fd5",
     "textLink.activeForeground": "#98c8ed",
     "titleBar.activeBackground": "#112233",

--- a/themes/WinterIsComing-dark-color-theme.json
+++ b/themes/WinterIsComing-dark-color-theme.json
@@ -643,6 +643,7 @@
     "tab.inactiveForeground": "#5f7e97",
     "tab.activeBorderTop": "#219fd5",
     "terminal.ansiBlack": "#282822",
+    "terminal.hoverHighlightBackground": "#219fd544",
     "textLink.foreground": "#219fd5",
     "textLink.activeForeground": "#98c8ed",
     "titleBar.activeBackground": "#112233",

--- a/themes/WinterIsComing-light-color-no-italics-theme.json
+++ b/themes/WinterIsComing-light-color-no-italics-theme.json
@@ -617,6 +617,7 @@
     "statusBarItem.prominentBackground": "#03648a",
     "statusBarItem.prominentHoverBackground": "#03648a",
     "terminal.ansiBlack": "#011627",
+    "terminal.hoverHighlightBackground": "#236ebf33",
     "textLink.foreground": "#236ebf",
     "textLink.activeForeground": "#236ebfcc",
     "titleBar.activeBackground": "#112233",

--- a/themes/WinterIsComing-light-color-theme.json
+++ b/themes/WinterIsComing-light-color-theme.json
@@ -631,6 +631,7 @@
     "statusBarItem.prominentBackground": "#03648a",
     "statusBarItem.prominentHoverBackground": "#03648a",
     "terminal.ansiBlack": "#011627",
+    "terminal.hoverHighlightBackground": "#236ebf33",
     "textLink.foreground": "#236ebf",
     "textLink.activeForeground": "#236ebfcc",
     "titleBar.activeBackground": "#112233",


### PR DESCRIPTION
## Description

Adds `terminal.hoverHighlightBackground` to all six theme variants so hovered terminal links use a subtle theme-colored highlight instead of the default dark blue bar behavior reported in #46.

Closes #46.

## Theme Variant(s) Changed

- [x] Dark Blue
- [x] Dark Blue - No Italics
- [x] Dark Black
- [x] Dark Black - No Italics
- [x] Light
- [x] Light - No Italics

## Changes

- `themes/WinterIsComing-dark-blue-color-theme.json` - added `terminal.hoverHighlightBackground: "#219fd544"`
- `themes/WinterIsComing-dark-blue-color-no-italics-theme.json` - added `terminal.hoverHighlightBackground: "#219fd544"`
- `themes/WinterIsComing-dark-color-theme.json` - added `terminal.hoverHighlightBackground: "#219fd544"`
- `themes/WinterIsComing-dark-color-no-italics-theme.json` - added `terminal.hoverHighlightBackground: "#219fd544"`
- `themes/WinterIsComing-light-color-theme.json` - added `terminal.hoverHighlightBackground: "#236ebf33"`
- `themes/WinterIsComing-light-color-no-italics-theme.json` - added `terminal.hoverHighlightBackground: "#236ebf33"`

## How to Test

1. Open this repo in VS Code and press `F5` to launch the Extension Development Host
2. Select any Winter is Coming theme, then open the integrated terminal
3. Run `echo "https://localhost"` and hover the link to verify the highlight is subtle and theme-colored

## Checklist

- [x] Color changes applied to both italics and no-italics variants
- [ ] `package.json` version bumped (if releasing)
- [ ] `CHANGELOG.md` updated
- [ ] Screenshots updated in `images/` (if colors changed significantly)
- [x] Ran `npx @vscode/vsce package --no-dependencies` successfully
