### PR TITLE
fix: reduce dark-theme line highlight opacity to distinguish from selection

### DIFF
--- a/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-no-italics-theme.json
@@ -594,7 +594,7 @@
     "editor.foreground": "#a7dbf7",
     "editor.inactiveSelectionBackground": "#7e57c25a",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",

--- a/themes/WinterIsComing-dark-blue-color-theme.json
+++ b/themes/WinterIsComing-dark-blue-color-theme.json
@@ -575,7 +575,7 @@
     "editor.foreground": "#a7dbf7",
     "editor.inactiveSelectionBackground": "#7e57c25a",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",

--- a/themes/WinterIsComing-dark-color-no-italics-theme.json
+++ b/themes/WinterIsComing-dark-color-no-italics-theme.json
@@ -560,7 +560,7 @@
     "editor.background": "#282822",
     "editor.foreground": "#a7dbf7",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",

--- a/themes/WinterIsComing-dark-color-theme.json
+++ b/themes/WinterIsComing-dark-color-theme.json
@@ -574,7 +574,7 @@
     "editor.background": "#282822",
     "editor.foreground": "#a7dbf7",
     "editor.hoverHighlightBackground": "#0c4994",
-    "editor.lineHighlightBackground": "#0c499477",
+    "editor.lineHighlightBackground": "#0c499444",
     "editor.selectionBackground": "#103362",
     "editor.selectionHighlightBackground": "#103362",
     "editor.findMatchHighlightBackground": "#103362",


### PR DESCRIPTION
## Summary

Reduces `editor.lineHighlightBackground` opacity in all four dark theme variants from `#0c499477` → `#0c499444` (alpha `0x77` → `0x44`), making the current-line highlight visually distinct from selected text.

Fixes #70

---

> ⚠️ **This PR supersedes #84**, which became conflicted after several fixes were merged into `master` (#85, #88, #89, #90, #91). This is a clean replacement branched from the latest `master` with only the original issue #70 fix applied.

## Changes

- `themes/WinterIsComing-dark-blue-color-theme.json`
- `themes/WinterIsComing-dark-blue-color-no-italics-theme.json`
- `themes/WinterIsComing-dark-color-theme.json`
- `themes/WinterIsComing-dark-color-no-italics-theme.json`

Light theme variants are unchanged (not affected by this issue).

## Testing

- `npx @vscode/vsce package --no-dependencies` completes successfully
- Manually verify in Dark Blue and Dark Black themes: the highlighted line is now subtly lighter than selected text regions