### PR TITLE
Bump actions/setup-node from 4 to 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
 


### PR DESCRIPTION
This supersedes #82 with the same one-line CI workflow update on a maintainer-owned branch.

## Summary
- bump `actions/setup-node` from `v4` to `v7` in `.github/workflows/ci.yml`
- preserve the rest of the existing CI workflow unchanged

## Notes
- created to avoid the workflow-file policy/auth friction blocking the original Dependabot PR
- packaging check: `npx @vscode/vsce package --no-dependencies`